### PR TITLE
Fix Child Scope Exception

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1,5 +1,8 @@
 trigger:
-- main
+  branches:
+    include:
+      - main
+      - feature/*
 
 pool:
   vmImage: 'windows-latest'

--- a/src/EtherGizmos.Extensions.DependencyInjection.ChildContainers/EtherGizmos.Extensions.DependencyInjection.ChildContainers.csproj
+++ b/src/EtherGizmos.Extensions.DependencyInjection.ChildContainers/EtherGizmos.Extensions.DependencyInjection.ChildContainers.csproj
@@ -13,7 +13,7 @@
     <Description>Introduces child DI containers and enables resolving services within the parent container after other parent services have been configured.</Description>
     <Authors>EtherFactor</Authors>
     <PackageTags>di;dependency;injection;nested;child;containers</PackageTags>
-    <PackageProjectUrl>https://github.com/etherfactor/extensions.dependencyinjection.childcontainers</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/etherfactor/extensions-dependencyinjection-childcontainers</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/src/EtherGizmos.Extensions.DependencyInjection.ChildContainers/Internal/ParentServiceProviderScopedSource.cs
+++ b/src/EtherGizmos.Extensions.DependencyInjection.ChildContainers/Internal/ParentServiceProviderScopedSource.cs
@@ -12,8 +12,7 @@ internal class ParentServiceProviderScopedSource
     /// <summary>
     /// The scoped parent service provider.
     /// </summary>
-    public IServiceProvider ParentProvider => _parentProvider
-        ?? throw new InvalidOperationException("No parent provider was specified");
+    public IServiceProvider? ParentProvider => _parentProvider;
 
     public void SetProvider(IServiceProvider parentProvider)
     {


### PR DESCRIPTION
Addresses an exception caused by creating a child scope from within a child service, then attempting to access a service outside that child scope.

Fixes [AB#179](https://dev.azure.com/EtherGizmos/3ea96ccc-e26a-4ef3-a497-6f9fc8e4b7d2/_workitems/edit/179).